### PR TITLE
Adds padding to the texts to prevent overflow

### DIFF
--- a/src/templates/QuoteCard.ts
+++ b/src/templates/QuoteCard.ts
@@ -31,7 +31,7 @@ class QuoteCard {
               .card {
                 font-family: ${font.family};
                 background-color: #${bg_color};
-                padding: 18px;
+                padding: 14px 18px;
                 width: 500px;
                 height: 200px;
                 border: ${border_width}px solid #${border_color};
@@ -43,7 +43,6 @@ class QuoteCard {
               .quote {
                 font-size: 18px;
                 color: #${quote_color};
-                padding: 0 16px;
                 line-height: 1.2;
               }
               .quote::before,
@@ -56,17 +55,18 @@ class QuoteCard {
               .quote::before {
                 content: open-quote;
                 text-align: left;
-                transform: translateX(-18px);
+                transform: translateX(-2px);
               }
               .quote::after {
                 content: close-quote;
                 text-align: right;
-                transform: translateX(18px);
+                transform: translateX(2px);
               }
               .author {
                 font-size: 14px;
                 font-style: italic;
                 color: #${author_color};
+                padding: 0 4px 4px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -76,9 +76,10 @@ class QuoteCard {
                 content: '';
                 width: 24px;
                 border-bottom: solid 3px #${accent_color};
-                margin-bottom: 16px;
+                margin-bottom: 10px;
               }
               .text-concat {
+                padding: 4px 16px;
                 display: -webkit-box;
                 -webkit-line-clamp: 3;
                 -webkit-box-orient: vertical;


### PR DESCRIPTION
## Type of Change

<!--
Please delete options that are not relevant.
 -->

- [x] 🐛 Bug Fix
- [x] 🎨 Style and UI

## Description

<!--
Please include a summary of the changes and the link to the ticket (jira/canban board etc). Please also include relevant motivation and context. List any dependencies that are required for this change.
 -->

- the upper and lower part of the letters for some fonts, such as Sofia and Garamond is cut off. This is due to the text-overflow hidden property of the texts.
- Adds padding to the texts, for both quote and author.

## Related Tickets & Documents

<!--
Using keywords such as Closes #10, or Fixes #5 links to the issue and closes it once the pull request is merged.

For multiple issues:
Resolves #10, resolves #123, resolves octo-org/octo-repo#100

For more information:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 -->

- Fixes #67 

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 -->

- [x] Before Fix
![68747470733a2f2f726561646d652d6461696c792d71756f7465732e76657263656c2e6170702f6170693f666f6e743d736f66696126617574686f723d53656e6563612671756f74653d4966253230612532306d616e2532306b6e6f77732532306e6f74253230746f2532307](https://github.com/cheehwatang/github-readme-daily-quotes/assets/81938708/8e658d0d-6212-49b1-b81d-2072e40ce5a7)

- [x] After Fix
![api](https://github.com/cheehwatang/github-readme-daily-quotes/assets/81938708/49c4bef6-e184-4e8f-ac8d-a303b7b19b83)

## Added or Updated Tests?

<!--
Please delete options that are not relevant.
 -->

- [x] 🙅 No, and this is why: visual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
