### PR TITLE
Add test for render quote card

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,4 +6,4 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 10%
+        threshold: 2%

--- a/src/test/renderQuoteCard.test.ts
+++ b/src/test/renderQuoteCard.test.ts
@@ -1,0 +1,53 @@
+import { renderQuoteCard } from '../app/renderQuoteCard';
+import { QuoteCard } from '../app/templates/QuoteCard';
+import { QuoteData } from '../app/utils/setQuoteData';
+import { Theme } from '../app/utils/setTheme';
+import { ThemeBorder } from '../app/utils/setBorder';
+import { FontData } from '../app/utils/setFont';
+
+describe('renderQuoteCard Test Suite', () => {
+	const sut = renderQuoteCard;
+
+	const buildMock = jest.fn();
+
+	beforeEach(() => {
+		QuoteCard.build = buildMock;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const dataMock: QuoteData = { quote: 'testQuote', author: 'testAuthor' };
+	const themeMock: Theme = {
+		bg_color: '000',
+		quote_color: '001',
+		author_color: '002',
+		accent_color: '003',
+		border_color: '004',
+	};
+	const borderMock: ThemeBorder = { border_width: 1, border_radius: 2 };
+	const fontMock: FontData = {
+		name: 'testFontName',
+		family: 'testFontFamily',
+		woff: 'testFontWoff',
+	};
+
+	it('should return the quote card string with the input data', () => {
+		buildMock.mockReturnValue(
+			[
+				Object.values(dataMock).join(),
+				Object.values(themeMock).join(),
+				Object.values(borderMock).join(),
+				Object.values(fontMock).join(),
+			].join()
+		);
+
+		const actual = sut(dataMock, themeMock, borderMock, fontMock);
+
+		expect(actual).toContain(Object.values(dataMock).join());
+		expect(actual).toContain(Object.values(themeMock).join());
+		expect(actual).toContain(Object.values(borderMock).join());
+		expect(actual).toContain(Object.values(fontMock).join());
+	});
+});


### PR DESCRIPTION
## Type of Change

<!--
Please delete options that are not relevant.
 -->

- [x] ✅ New Test

## Description

<!--
Please include a summary of the changes and the link to the ticket (jira/canban board etc). Please also include relevant motivation and context. List any dependencies that are required for this change.
 -->
- add test for renderQuoteCard.ts
- update codecov threshold to 2%

## Related Tickets & Documents

<!--
Using keywords such as Closes #10, or Fixes #5 links to the issue and closes it once the pull request is merged.

For multiple issues:
Resolves #10, resolves #123, resolves octo-org/octo-repo#100

For more information:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 -->

- Fixes #80 

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 -->

- renderQuoteCard method is tested to see if the values are passed to QuoteCard.build.

## Added or Updated Tests?

<!--
Please delete options that are not relevant.
 -->

- [x] 👍 Yes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
